### PR TITLE
Fixed record selection bug

### DIFF
--- a/src/aura/leadMassAssignPage/leadMassAssignPage.cmp
+++ b/src/aura/leadMassAssignPage/leadMassAssignPage.cmp
@@ -69,9 +69,9 @@
       </tr>
     </thead>
     <tbody>
-      <aura:iteration items="{!v.leads}" var="theLead">
+      <aura:iteration items="{!v.leads}" var="theLead" indexVar="i">
         <tr>
-          <th scope="row">0</th>
+          <th scope="row">{!i + 1}</th>
           <td>
             <label class="slds-checkbox">
               <input type="checkbox" checked="true" disabled="true" />

--- a/src/pages/LeadMassAssignSlds.page
+++ b/src/pages/LeadMassAssignSlds.page
@@ -18,7 +18,7 @@
     $Lightning.use("c:visualforceApp", function() {
       $Lightning.createComponent("c:leadMassAssignPage", {
         leads: [
-          <apex:repeat value="{!leads}" var="theLead">
+          <apex:repeat value="{!selected}" var="theLead">
             {
               Id: "{!theLead.Id}",
               Name: "{!theLead.Name}",


### PR DESCRIPTION
Previously, all records from the list view were displayed in the mass assign page, instead of displaying only _selected_ records. This pr also includes a hotfix to correctly render the record index in the data table on the mass assign page.